### PR TITLE
Distributional DQN (QR-DQN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ### Rainbow
 
-- [x] DQN (base agent)
-- [x] Dobule DQN
-- [x] Prioritized Experience Replay
-- [x] Dueling DQN
-- [x] Multi step Q learning
-- [ ] Distributional DQN
+- [x] [DQN](https://arxiv.org/abs/1312.5602) (base agent)
+- [x] [Dobule DQN](https://arxiv.org/abs/1509.06461)
+- [x] [Prioritized Experience Replay](https://arxiv.org/abs/1511.05952)
+- [x] [Dueling DQN](https://arxiv.org/abs/1511.06581)
+- [x] [Multi step Q learning](https://arxiv.org/abs/1703.01327)
+- [x] Distributional DQN ([QR-DQN](https://arxiv.org/abs/1710.10044))
 - [ ] Noisy DQN
 
 ## Build

--- a/modules/agent/dqn.py
+++ b/modules/agent/dqn.py
@@ -255,13 +255,13 @@ class DQNAgent:
 
     def get_loss_q(self, q: Tensor, target: Tensor) -> Tensor:
         loss_fn = nn.MSELoss()
-        loss_q = loss_fn(q, target)
-        return loss_q
+        loss = loss_fn(q, target)
+        return loss
 
     def get_loss_v(self, v: Tensor, target: Tensor) -> Tensor:
         loss_fn = nn.MSELoss()
-        loss_q = loss_fn(v, target)
-        return loss_q
+        loss = loss_fn(v, target)
+        return loss
 
     def get_loss(self, loss_q: Tensor, loss_v: Tensor) -> Tensor:
         return loss_q + loss_v

--- a/modules/agent/dqn.py
+++ b/modules/agent/dqn.py
@@ -253,6 +253,19 @@ class DQNAgent:
             done=done_list,
         )
 
+    def get_loss_q(self, q: Tensor, target: Tensor) -> Tensor:
+        loss_fn = nn.MSELoss()
+        loss_q = loss_fn(q, target)
+        return loss_q
+
+    def get_loss_v(self, v: Tensor, target: Tensor) -> Tensor:
+        loss_fn = nn.MSELoss()
+        loss_q = loss_fn(v, target)
+        return loss_q
+
+    def get_loss(self, loss_q: Tensor, loss_v: Tensor) -> Tensor:
+        return loss_q + loss_v
+
     def update(self, example: List[Example]) -> float:
         tensor_examples = self.to_tensor(example)
         qs, v = self.qvnet(tensor_examples.state)  # qs.size(): (N, 7) / vs.size(): (N, 1)
@@ -261,10 +274,9 @@ class DQNAgent:
             tensor_examples.reward, tensor_examples.next_state, tensor_examples.done
         )
 
-        loss_fn = nn.MSELoss()
-        loss_q = loss_fn(q, target)
-        loss_v = loss_fn(v.flatten(), tensor_examples.winning_player)
-        loss = loss_q + loss_v
+        loss_q = self.get_loss_q(q, target)
+        loss_v = self.get_loss_v(v.flatten(), tensor_examples.winning_player)
+        loss = self.get_loss(loss_q, loss_v)
 
         self.optimizer.zero_grad()
         loss.backward()

--- a/modules/agent/dqn.py
+++ b/modules/agent/dqn.py
@@ -16,10 +16,18 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
 
 from conf.game_conf import BOARD_COLUMN  # noqa
 from modules.typings import BoardType, Example, TensorExamples  # noqa
+from modules.utils.model_utils import (  # noqa
+    calculate_quantile_huber_loss,
+    disable_gradients,
+    evaluate_quantile_at_action,
+    update_params,
+)
 
 
 @dataclass
 class DQNParams:
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
     gamma: float = 0.98
     action_size: int = BOARD_COLUMN
     lr: float = 0.0005
@@ -29,6 +37,7 @@ class DQNParams:
     buffer_size: int = 10000
     batch_size: int = 32
     multi_step_td_target: int = 2  # multi step learningのステップ数。1の時、TD法
+    num_taus: int = 200  # QR-DQNにおける分位の数。1の時、シンプルなQ-learning
 
 
 class QVNet(nn.Module):
@@ -46,6 +55,7 @@ class QVNet(nn.Module):
     def __init__(
         self,
         action_size: int,
+        num_taus: int,
         drop_path_rate: float = 0.2,
         dims: Union[List[int], None] = None,
         depths: Union[List[int], None] = None,
@@ -54,6 +64,7 @@ class QVNet(nn.Module):
     ) -> None:
         super().__init__()
         self.action_size = action_size
+        self.num_taus = num_taus
         self.dueling = dueling
         if dims is None:
             dims = [96, 192, 384, 768]
@@ -91,15 +102,15 @@ class QVNet(nn.Module):
         if self.dueling:
             self.dueling_qv_head = nn.Sequential(
                 nn.Linear(dims[-1], dims[-1]),
-                nn.Linear(dims[-1], 1),
+                nn.Linear(dims[-1], self.num_taus),
             )
             self.dueling_qa_head = nn.Sequential(
                 nn.Linear(dims[-1], dims[-1]),
-                nn.Linear(dims[-1], action_size),
+                nn.Linear(dims[-1], self.action_size * self.num_taus),
             )
         else:
             self.q_head = nn.Sequential(
-                nn.Linear(dims[-1], action_size),
+                nn.Linear(dims[-1], self.action_size * self.num_taus),
             )
         self.v_head = nn.Sequential(
             nn.Linear(dims[-1], 1),
@@ -119,12 +130,12 @@ class QVNet(nn.Module):
         x = self._one_hot(x).float()
         x = self.forward_features(x)
         if self.dueling:
-            q_v = self.dueling_qv_head(x)
-            q_a = self.dueling_qa_head(x)
-            mean_q_a = q_a.mean(1).unsqueeze(1)  # 各アクションに対するAdvantageの平均
-            q = q_v.expand(-1, self.action_size) + (q_a - mean_q_a.expand(-1, self.action_size))
+            q_v = self.dueling_qv_head(x).view(-1, self.num_taus, 1)
+            q_a = self.dueling_qa_head(x).view(-1, self.num_taus, self.action_size)
+            mean_q_a = q_a.mean(dim=2, keepdim=True)  # 各アクションに対するAdvantageの平均
+            q = q_v + q_a - mean_q_a
         else:
-            q = self.q_head(x)
+            q = self.q_head(x).view(-1, self.num_taus, self.action_size)
         v = self.v_head(x)
         return q, v
 
@@ -135,9 +146,19 @@ class QVNet(nn.Module):
             return x.permute(2, 0, 1).unsqueeze(0)  # (N, C, H, W)
         return x.permute(0, 3, 1, 2)  # (N, C, H, W)
 
+    def calculate_q(self, states: Tensor) -> Tensor:
+        # Calculate quantiles.
+        qs, _ = self(states)
+
+        # Calculate expectations of value distributions.
+        q: Tensor = qs.mean(dim=1)
+
+        return q
+
 
 class DQNAgent:
     def __init__(self, params: DQNParams) -> None:
+        self.device = params.device
         self.gamma = params.gamma
         self.lr = params.lr
         self.epsilon = params.epsilon
@@ -147,10 +168,23 @@ class DQNAgent:
         self.double_dqn = params.double_dqn
         self.dueling = params.dueling
         self.multi_step_td_target = params.multi_step_td_target
+        self.num_taus = params.num_taus
 
-        self.qvnet = QVNet(self.action_size, dims=[96], depths=[3], dueling=self.dueling)
-        self.qvnet_target = QVNet(self.action_size, dims=[96], depths=[3], dueling=self.dueling)
+        self.qvnet = QVNet(
+            self.action_size, self.num_taus, dims=[96], depths=[3], dueling=self.dueling
+        )
+        self.qvnet_target = QVNet(
+            self.action_size, self.num_taus, dims=[96], depths=[3], dueling=self.dueling
+        )
+        disable_gradients(self.qvnet_target)
         self.optimizer = optim.Adam(self.qvnet.parameters(), lr=self.lr)
+
+        # Fixed fractions.
+        taus = (
+            torch.arange(0, self.num_taus + 1, device=self.device, dtype=torch.float32)
+            / self.num_taus
+        )
+        self.tau_hats = ((taus[1:] + taus[:-1]) / 2.0).view(1, self.num_taus)
 
     def get_action(self, state: BoardType) -> int:
         """e-greedy法によって行動選択する
@@ -166,7 +200,7 @@ class DQNAgent:
         else:
             state = torch.from_numpy(deepcopy(state))
             qs, _ = self.qvnet(state)
-            return int(qs.argmax().item())
+            return int(qs.sum(dim=1).argmax().item())
 
     def get_target(self, reward: Tensor, next_state: Tensor, done: Tensor) -> Tensor:
         """TDターゲットを返す
@@ -180,20 +214,24 @@ class DQNAgent:
             Tensor: TDターゲット
         """
         if self.double_dqn:
-            target = self.get_ddqn_target(reward, next_state, done)
+            next_q = self.get_next_q_for_ddqn(reward, next_state, done)
         else:
-            target = self.get_default_target(reward, next_state, done)
+            next_q = self.get_next_q(reward, next_state, done)
+        next_q.detach()
+        target = self.get_td_target(reward, done, next_q)
         return target
 
     def get_td_target(self, reward: Tensor, done: Tensor, next_q: Tensor) -> Tensor:
         gamma = self.gamma**self.multi_step_td_target
-        td_target: Tensor = reward + (1 - done.to(torch.int)) * gamma * next_q
+        reward = reward.unsqueeze(-1).unsqueeze(-1)  # (B, ) -> (B, 1, 1)
+        done = done.to(torch.int).unsqueeze(-1).unsqueeze(-1)  # (B, ) -> (B, 1, 1)
+        td_target: Tensor = reward + (1 - done) * gamma * next_q
         return td_target
 
-    def get_default_target(self, reward: Tensor, next_state: Tensor, done: Tensor) -> Tensor:
-        """通常のDQNのTDターゲットを返す
+    def get_next_q(self, reward: Tensor, next_state: Tensor, done: Tensor) -> Tensor:
+        """通常のDQNにおいて、次の状態next_stateにおけるQ関数を返す
 
-        TDターゲット = reward + gamma * max_a qnet_target(next_state)
+        next_q = max_a qnet_target(next_state)
 
         Args:
             reward (Tensor): 報酬
@@ -201,21 +239,21 @@ class DQNAgent:
             done (Tensor): エピソードが終了したか
 
         Returns:
-            Tensor: TDターゲット
+            Tensor: next_q
         """
-        next_qs, _ = self.qvnet_target(next_state)
-        next_q = next_qs.max(1)[0]
-        next_q.detach()
-        target = self.get_td_target(reward, done, next_q)
-        return target
+        next_qs = self.qvnet_target.calculate_q(next_state)
+        next_q: Tensor = next_qs.max(2).unsqueeze(2).transpose(1, 2)
+        assert next_q.shape == (self.batch_size, 1, self.num_taus)
 
-    def get_ddqn_target(self, reward: Tensor, next_state: Tensor, done: Tensor) -> Tensor:
-        """過大評価を解消するTDターゲットを返す
+        return next_q
+
+    def get_next_q_for_ddqn(self, reward: Tensor, next_state: Tensor, done: Tensor) -> Tensor:
+        """過大評価を解消するように、次の状態next_stateにおけるQ関数を返す
         qnet_target(next_state)は誤差が含まれる推定値であり、この最大値を取ると、真のQ関数より過大評価されてしまう
         Double DQNでは、真のQ関数qnet(next_state)が最大となる行動を選び、
-        その行動を取ったときのqnet_target(next_state)を使ってTDターゲットを作る
+        その行動を取ったときのqnet_target(next_state)を返す
 
-        TDターゲット = reward + gamma * qnet_target(next_state, a=argmax_a qnet(next_state))
+        next_q = qnet_target(next_state, a=argmax_a qnet(next_state))
 
         Args:
             reward (Tensor): 報酬
@@ -225,13 +263,19 @@ class DQNAgent:
         Returns:
             Tensor: TDターゲット
         """
-        qs, _ = self.qvnet(next_state)
-        q_max_action = qs.argmax(axis=1)
-        next_qs, _ = self.qvnet_target(next_state)
-        next_q = torch.tensor([qi[a] for qi, a in zip(next_qs, q_max_action)])
-        next_q.detach()
-        target = self.get_td_target(reward, done, next_q)
-        return target
+        qs = self.qvnet.calculate_q(next_state)
+        # Calculate greedy actions.
+        q_max_actions = torch.argmax(qs, dim=1, keepdim=True).squeeze(1)
+        assert q_max_actions.shape == (self.batch_size,)
+
+        # Calculate quantile values of next states and actions at tau_hats.
+        target_qs, _ = self.qvnet_target(next_state)
+        next_sa_quantiles: Tensor = evaluate_quantile_at_action(target_qs, q_max_actions).transpose(
+            1, 2
+        )
+        assert next_sa_quantiles.shape == (self.batch_size, 1, self.num_taus)
+
+        return next_sa_quantiles
 
     def to_tensor(self, data: List[Example]) -> TensorExamples:
         states = torch.tensor(np.stack([x.state for x in data]))
@@ -254,13 +298,14 @@ class DQNAgent:
         )
 
     def get_loss_q(self, q: Tensor, target: Tensor) -> Tensor:
-        loss_fn = nn.MSELoss()
-        loss = loss_fn(q, target)
-        return loss
+        td_errors = q - target
+        assert td_errors.shape == (self.batch_size, self.num_taus, self.num_taus)
+        quantile_huber_loss: Tensor = calculate_quantile_huber_loss(td_errors, self.tau_hats)
+        return quantile_huber_loss
 
     def get_loss_v(self, v: Tensor, target: Tensor) -> Tensor:
         loss_fn = nn.MSELoss()
-        loss = loss_fn(v, target)
+        loss: Tensor = loss_fn(v, target)
         return loss
 
     def get_loss(self, loss_q: Tensor, loss_v: Tensor) -> Tensor:
@@ -268,19 +313,24 @@ class DQNAgent:
 
     def update(self, example: List[Example]) -> float:
         tensor_examples = self.to_tensor(example)
-        qs, v = self.qvnet(tensor_examples.state)  # qs.size(): (N, 7) / vs.size(): (N, 1)
-        q = qs[np.arange(len(tensor_examples.action)), tensor_examples.action]
-        target = self.get_target(
-            tensor_examples.reward, tensor_examples.next_state, tensor_examples.done
-        )
+        qs, v = self.qvnet(
+            tensor_examples.state
+        )  # qs.size(): (N, num_taus, action_size) / vs.size(): (N, num_taus, 1)
 
-        loss_q = self.get_loss_q(q, target)
+        # Calculate quantile values of current states and actions at taus.
+        current_sa_quantiles = evaluate_quantile_at_action(qs, tensor_examples.action)
+        assert current_sa_quantiles.shape == (self.batch_size, self.num_taus, 1)
+        with torch.no_grad():
+            target_sa_quantiles = self.get_target(
+                tensor_examples.reward, tensor_examples.next_state, tensor_examples.done
+            )
+        assert target_sa_quantiles.shape == (self.batch_size, 1, self.num_taus)
+
+        loss_q = self.get_loss_q(q=current_sa_quantiles, target=target_sa_quantiles)
         loss_v = self.get_loss_v(v.flatten(), tensor_examples.winning_player)
         loss = self.get_loss(loss_q, loss_v)
 
-        self.optimizer.zero_grad()
-        loss.backward()
-        self.optimizer.step()
+        update_params(self.optimizer, loss, retain_graph=False)
         return float(loss.item())
 
     def sync_qvnet(self) -> None:

--- a/modules/utils/model_utils.py
+++ b/modules/utils/model_utils.py
@@ -1,0 +1,76 @@
+from collections import deque
+import numpy as np
+import torch
+from torch import Tensor
+import torch.nn as nn
+
+
+def update_params(
+    optim: torch.optim.Optimizer,
+    loss: Tensor,
+    retain_graph: bool=False,
+) -> None:
+    optim.zero_grad()
+    loss.backward(retain_graph=retain_graph)  # type: ignore[no-untyped-call]
+    optim.step()
+
+
+def disable_gradients(network: nn.Module) -> None:
+    # Disable calculations of gradients.
+    for param in network.parameters():
+        param.requires_grad = False
+
+
+def calculate_huber_loss(td_errors: Tensor, kappa: float=1.0) -> Tensor:
+    """
+    Calculate huber loss element-wisely depending on kappa.
+    if |td_errors| ≤ kappa:
+        huber_loss = 0.5 * td_errors ** 2
+    else:
+        huber_loss = kappa * (|td_errors| - 0.5 * kappa)
+    """
+    loss = torch.where(
+        td_errors.abs() <= kappa,
+        0.5 * td_errors.pow(2),
+        kappa * (td_errors.abs() - 0.5 * kappa)
+    )
+    return loss
+
+
+def calculate_quantile_huber_loss(td_errors: Tensor, taus: Tensor, kappa: float=1.0) -> Tensor:
+    assert not taus.requires_grad
+    batch_size, N, N_dash = td_errors.shape
+
+    # Calculate huber loss element-wisely.
+    element_wise_huber_loss = calculate_huber_loss(td_errors, kappa)
+    assert element_wise_huber_loss.shape == (batch_size, N, N_dash)
+
+    # Calculate quantile huber loss element-wisely.
+    # see: https://arxiv.org/pdf/1710.10044.pdf -> equation (10)
+    element_wise_quantile_huber_loss = torch.abs(
+        taus[..., None] - (td_errors.detach() < 0).float()
+    ) * element_wise_huber_loss / kappa
+    assert element_wise_quantile_huber_loss.shape == (batch_size, N, N_dash)
+
+    # Quantile huber loss.
+    batch_quantile_huber_loss = element_wise_quantile_huber_loss.sum(dim=1).mean(dim=1, keepdim=True)
+    assert batch_quantile_huber_loss.shape == (batch_size, 1)
+    
+    quantile_huber_loss = batch_quantile_huber_loss.mean()
+
+    return quantile_huber_loss
+
+
+def evaluate_quantile_at_action(s_quantiles: Tensor, actions: Tensor) -> Tensor:
+    assert s_quantiles.shape[0] == actions.shape[0]
+
+    batch_size = s_quantiles.shape[0]
+    N = s_quantiles.shape[1]
+
+    # Expand actions into (batch_size, N, 1).
+    action_index = actions.unsqueeze(-1).unsqueeze(-1).expand(batch_size, N, 1)
+
+    # Calculate quantile values at specified actions.
+    sa_quantiles = s_quantiles.gather(dim=2, index=action_index)
+
+    return sa_quantiles


### PR DESCRIPTION
Distributional なQ関数を導入するために、QR-DQNを実装

QR-DQNは、Distributional DQNのいくつかの課題を解決している
- Distributional DQNではx軸のカテゴリカル分布で`Z(s,a)`を近似していたが、ベルマンオペレータの適用によってビン幅がずれるため煩雑なビンの再割り当て処理(projection)が必要だった一方え、QR DQNではカテゴリカル分布で価値分布の累積分布関数をy軸にそってモデル化する、すなわち累積分布関数の逆関数を近似するためビン幅ずれ問題から回避
- QR-DQNでは、カテゴリカル分布の最大値と最小値の設定に依存しない。なぜなら、累積分布関数の逆関数は0-1の有限区間で定義される関数だから
- 直接Wasserstein距離をロス関数として使用することを回避しながらWasserstein距離を最小化できるような損失設計
   - Distributional DQNの最大の残課題は理論的にはWasserstein距離を最小化したいが、Wasserstein距離をそのままロス関数として、SGDなどで勾配降下させるとBiased gradientとなってしまうため代わりに分布間のKL距離を最小していた
   - そこでQR-DQNではターゲット分布の分位点を予測することがWasserstein距離を最小化することを示し、このためにSGDのロス関数に分位点回帰を使用することを提案した
